### PR TITLE
Fix typos

### DIFF
--- a/advanced/deface_overrides_tutorial.md
+++ b/advanced/deface_overrides_tutorial.md
@@ -120,7 +120,7 @@ As Spree views are changed over coming versions, the original HTML elements mayb
 
 For example, spree/products/show.html.erb looks as follows:
 
-```text
+```erb
 <div data-hook="product_show" itemscope itemtype="http://schema.org/Product">
   <%% body_id = 'product-details' %>
   <div class="columns six alpha" data-hook="product_left_part">

--- a/advanced/existing_app_tutorial.md
+++ b/advanced/existing_app_tutorial.md
@@ -16,8 +16,8 @@ gem 'spree_emails' # transactional emails (optional)
 gem 'spree_sample' # dummy data like products, taxons, etc
 gem 'spree_auth_devise', '~> 4.3' # Devise integration (optional)
 gem 'spree_gateway', '~> 3.9' # payment gateways eg. Stripe, Braintree (optional)
-gem 'spree_i18n', '~> 5.0' # translation files (optional) 
- 
+gem 'spree_i18n', '~> 5.0' # translation files (optional)
+
 # only needed for MacOS and Ruby 3.0
 gem 'sassc', github: 'sass/sassc-ruby', branch: 'master'
 ```
@@ -52,7 +52,7 @@ You can always perform any of these steps later by using these commands.
 bin/rake railties:install:migrations
 bin/rails db:migrate
 bin/rails db:seed
-bin/rake spree_sampe:load
+bin/rake spree_sample:load
 ```
 
 ### Mounting the Spree engine

--- a/advanced/extend_product_attributes.md
+++ b/advanced/extend_product_attributes.md
@@ -7,15 +7,15 @@ section: tutorial
 
 ## Overview
 
-If you need to add more attributes to your product model you can easily extend spree. In this example you are going to extend your product with an `short_descripton` and make it manageable through admin.
+If you need to add more attributes to your product model you can easily extend Spree. In this example you are going to extend your product with a `short_description` and make it manageable through admin.
 
-Note: Replace `RailsappName` and `railsapp_name` with your actualy Rails App Name \(sic!\)
+Note: Replace `RailsappName` and `railsapp_name` with your actual Rails App Name \(sic!\)
 
 ## Extend your Product
 
 ### Extend Product Attributes
 
-Create a migration that extends your spree products table. `rails g migration AddFieldsToSpreeProducts short_description:text` should create this migration
+Create a migration that extends your Spree products table. `rails g migration AddFieldsToSpreeProducts short_description:text` should create this migration
 
 ```ruby
 class AddFieldsToSpreeProducts < ActiveRecord::Migration[5.2]
@@ -67,7 +67,7 @@ File Location: `app/serializers/railsapp_name/spree/product_serializer_decorator
 
 _Create Template for Admin Form_
 
-```ruby
+```erb
 <div data-hook="admin_product_form_short_description">
   <%= f.field_container :short_description, class: ['form-group'] do %>
     <%= f.label :short_description %>

--- a/contributing/developing_spree.md
+++ b/contributing/developing_spree.md
@@ -18,14 +18,14 @@ Go to [Spree GitHub repository](https://github.com/spree/spree) and click **Fork
 
 1. Clone the your fork repository
 
-   ```text
+   ```bash
     git clone git://github.com/your_github_username/spree.git
     cd spree
    ```
 
 2. Install the gem dependencies
 
-   ```text
+   ```bash
     bundle install
    ```
 
@@ -35,7 +35,7 @@ If `bundle install` fails that means you're missing some required system librari
 
 Firstly, ensure you hve [homebrew installed](https://brew.sh/). You will need to install some packages needed to run Spree and Rails applications in general:
 
-```text
+```bash
 brew install openssl mysql postgresql sqlite imagemagick redis
 ```
 
@@ -45,37 +45,37 @@ Spree is meant to be run within the context of Rails application and the source 
 
 This will setup a Rails application with Spree and some essential extensions and gems pre-installed with some data seeded Sandbox application is not meant to be run on production!
 
-```text
+```bash
 bundle exec rake sandbox
 ```
 
 For **headless sandbox** please run:
 
-```text
+```bash
 SPREE_HEADLESS=true bundle exec rake sandbox
 ```
 
 By default Sandbox uses **SQLite** database. But you can switch to **PostgreSQL**:
 
-```text
+```bash
 DB=postgres bundle exec rake sandbox
 ```
 
 or **MySQL**:
 
-```text
+```bash
 DB=mysql bundle exec rake sandbox
 ```
 
 You can also combine those options:
 
-```text
+```bash
 SPREE_HEADLESS=true DB=postgres bundle exec rake sandbox
 ```
 
 Start the server
 
-```text
+```bash
 cd sandbox
 bin/rails s
 ```
@@ -113,7 +113,7 @@ You can see the build statuses at [https://circleci.com/gh/spree/spree](https://
 
 Each gem contains its own series of tests, and for each directory, you need to do a quick one-time creation of a test application and then you can use it to run the tests. For example, to run the tests for the core project.
 
-```text
+```bash
 cd core
 bundle exec rake test_app
 bundle exec rspec
@@ -121,20 +121,20 @@ bundle exec rspec
 
 If you would like to run specs against a particular database you may specify the dummy app's database, which defaults to sqlite3.
 
-```text
+```bash
 DB=postgres bundle exec rake test_app
 ```
 
 If you want to run specs for only a single spec file
 
-```text
+```bash
 cd core
 bundle exec rspec spec/models/spree/state_spec.rb
 ```
 
 If you want to run a particular line of spec
 
-```text
+```bash
 cd core
 bundle exec rspec spec/models/spree/state_spec.rb:7
 ```
@@ -153,7 +153,7 @@ Please keep your commit history meaningful and clear. [This guide](https://about
 
 1. Push your changes to a topic branch in your fork of the repository.
 
-   ```text
+   ```bash
     git push -u origin fix/order-recalculation-total-bug
    ```
 
@@ -164,7 +164,7 @@ Please keep your commit history meaningful and clear. [This guide](https://about
 3. Wait for CI to pass
 4. If CI passed wait for Spree Core team code review
 
-   We're aiming to review and leave feedback as soon as possible. We'll leave you a meaningul feedback if needed.
+   We're aiming to review and leave feedback as soon as possible. We'll leave you a meaningful feedback if needed.
 
 ## That's a wrap!
 

--- a/customization/api_v1.md
+++ b/customization/api_v1.md
@@ -134,7 +134,7 @@ module Spree
     let!(:user) { create(:user) }
 
     before do
-      # Mock API autentication using a "spree_api_key"
+      # Mock API authentication using a "spree_api_key"
       stub_authentication!
     end
 

--- a/customization/storefront.md
+++ b/customization/storefront.md
@@ -7,7 +7,7 @@ order: 0
 # Storefront
 
 {% hint style="info" %}
-This sections covers the Rails based storefront which was extracted to `spree_frontend` ruby gem. 
+This sections covers the Rails based storefront which was extracted to `spree_frontend` ruby gem.
 {% endhint %}
 
 ## Styling with SASS variables
@@ -54,7 +54,7 @@ _**$font-family**_ - this sets the font family used across your site. By default
 
 ### Input fields
 
-_**$input-background**_ - this allows you to set a color for all input field backgrounds across the site. See two examples of a white and a yellow backround below.
+_**$input-background**_ - this allows you to set a color for all input field backgrounds across the site. See two examples of a white and a yellow background below.
 
 _**$second-global-border**_ - this allows you to set a color for all input field borders across the whole site. See an example below with red input field borders.
 

--- a/deployment/heroku.md
+++ b/deployment/heroku.md
@@ -16,7 +16,7 @@ We recommend you start and stick to Heroku if you do not have DevOps-skilled tea
 
 ## Dynos
 
-[Heroku Dynos](https://www.heroku.com/dynos) are lightweight, isolated environments that provide compute and run yuor application.
+[Heroku Dynos](https://www.heroku.com/dynos) are lightweight, isolated environments that provide compute and run your application.
 
 There's 2 type of dynos:
 

--- a/extensions/extensions_tutorial.md
+++ b/extensions/extensions_tutorial.md
@@ -12,7 +12,7 @@ Let's build a simple extension. Suppose we want the ability to mark certain prod
 
 Before we start, let's make sure we have spree command installed by running:
 
-```ruby
+```bash
 gem install spree
 ```
 

--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -8,7 +8,7 @@ If you would like to add Spree to your existing Ruby on Rails application, pleas
 
 ### Windows
 
-Windows users will need to [install the Linux subsystem](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to proceed.
+Windows users will need to [install Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to proceed.
 
 ## Installation
 

--- a/getting-started/understanding_spree.md
+++ b/getting-started/understanding_spree.md
@@ -20,7 +20,7 @@ All Spree models, controllers and other classes are namespaced by the `Spree` ke
 
 ## Spree modules
 
-Spree is divided into several modules / gems which you can opt-out if you would like. Installing Spree via Spree Starter gives you access to all of Spree features such as Stoprefront, API and Admin Panel. Not all of the modules are required, eg. headless installations will not require Storefront at all.
+Spree is divided into several modules / gems which you can opt-out if you would like. Installing Spree via Spree Starter gives you access to all of Spree features such as Storefront, API and Admin Panel. Not all of the modules are required, eg. headless installations will not require Storefront at all.
 
 | Spree module | Description | Required? |
 | :--- | :--- | :--- |

--- a/internals/shipments.md
+++ b/internals/shipments.md
@@ -458,7 +458,7 @@ Rails.application.config.spree.stock_splitters = [
 ]
 ```
 
-Or if you don't want to split packages just set the option above to an empty array. e.g. a store with the following configuration in spree.rb won't have any package splitted.
+Or if you don't want to split packages just set the option above to an empty array. e.g. a store with the following configuration in `spree.rb` won't have any package split:
 
 ```ruby
 Rails.application.config.spree.stock_splitters = []

--- a/security/pci_compliance.md
+++ b/security/pci_compliance.md
@@ -8,7 +8,7 @@ order: 1
 
 ## Overview
 
-All store owners wishing to process credit card transactions should be familiar with [PCI Compliance](http://en.wikipedia.org/wiki/Pci_compliance). [Spree Gateway Stripe itnegration](https://github.com/spree/spree_gateway) and [Spree Braintree vzero](https://github.com/spree-contrib/spree_braintree_vzero) are PCI-compliant.
+All store owners wishing to process credit card transactions should be familiar with [PCI Compliance](http://en.wikipedia.org/wiki/Pci_compliance). [Spree Gateway Stripe integration](https://github.com/spree/spree_gateway) and [Spree Braintree vzero](https://github.com/spree-contrib/spree_braintree_vzero) are PCI-compliant.
 
 ## Transmit Exactly Once
 
@@ -16,9 +16,9 @@ Spree uses extreme caution in its handling of credit cards. In production mode, 
 
 Spree does store the last four digits of the credit card and the expiration month and date. You could easily customize Spree further if you wanted and opt out of storing even that little bit of information.
 
-## 3-D Secure and Strong Customer Authenthication support
+## 3-D Secure and Strong Customer Authentication support
 
-[Spree Gateway Stripe itnegration](https://github.com/spree/spree_gateway) supports [Strong Customer Authentication \(SCA\)](https://stripe.com/en-pl/guides/strong-customer-authentication) out of the box. Remember to use S**tripe Elements** gateway with **Payment Intents** option enabled.
+[Spree Gateway Stripe integration](https://github.com/spree/spree_gateway) supports [Strong Customer Authentication \(SCA\)](https://stripe.com/en-pl/guides/strong-customer-authentication) out of the box. Remember to use S**tripe Elements** gateway with **Payment Intents** option enabled.
 
 [Spree Braintree vzero](https://github.com/spree-contrib/spree_braintree_vzero) extension supports [3D Secure 2.0](https://developers.braintreepayments.com/guides/3d-secure/overview).
 


### PR DESCRIPTION
This PR mostly fixes typos, changes highlight language for some code blocks (based on the code blocks content) and uses "Windows Subsystem for Linux" instead of "Linux subsystem", since "Windows Subsystem for Linux" is the official name and is even called WSL everywhere in the Microsoft WSL documentation.
https://docs.microsoft.com/en-us/windows/wsl/install-win10