### PR TITLE
Installation: Fix Windows Subsystem for Linux (WSL) name

### DIFF
--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -8,7 +8,7 @@ If you would like to add Spree to your existing Ruby on Rails application, pleas
 
 ### Windows
 
-Windows users will need to [install the Linux subsystem](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to proceed.
+Windows users will need to [install Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to proceed.
 
 ## Installation
 


### PR DESCRIPTION
This PR uses "Windows Subsystem for Linux" instead of "Linux subsystem", since "Windows Subsystem for Linux" is the official name and is even called WSL everywhere in the Microsoft WSL documentation.
https://docs.microsoft.com/en-us/windows/wsl/install-win10