### PR TITLE
Replace `yarn` commands with `npm` commands

### DIFF
--- a/storefronts/next.js-commerce.md
+++ b/storefronts/next.js-commerce.md
@@ -23,5 +23,5 @@ See the live demo: [https://spree.vercel.app/](https://spree.vercel.app/)
 3. Adjust the `NEXT_PUBLIC_SPREE_CATEGORIES_TAXONOMY_PERMALINK` and `NEXT_PUBLIC_SPREE_BRANDS_TAXONOMY_PERMALINK` environment variables inside `.env.local`:
    * They rely on [taxonomies'](https://dev-docs.spreecommerce.org/internals/products#taxons-and-taxonomies) `permalink` values set in Spree.
    * Go to the Spree admin panel and create `Categories` and `Brands` taxonomies if they don't exist. Copy their permalinks into `.env.local` in NextJS Commerce.
-4. Finally, run `yarn dev` .
+4. Finally, run `npm install` and `npm run dev`.
 


### PR DESCRIPTION
NextJS Commerce switched to `npm`.