### PR TITLE
Remove escapes

### DIFF
--- a/internals/promotions.md
+++ b/internals/promotions.md
@@ -22,7 +22,7 @@ Promotions relate to two other main components: `actions` and `rules`. When a pr
 
 In some special cases where a promotion has a `code` or a `path` configured for it, the promotion will only be activated if the payload's code or path match the promotion's. The `code` attribute is used for promotion codes, where a user must enter a code to receive the promotion, and the `path` attribute is used to apply a promotion once a user has visited a specific path.
 
- Path-based promotions will only work when the \`Spree::PromotionHandler::Page\` class is used, as in \`Spree::ContentController\` from \`spree\_frontend\`.
+ Path-based promotions will only work when the `Spree::PromotionHandler::Page` class is used, as in `Spree::ContentController` from `spree_frontend`.
 
 A promotion may also have a `usage_limit` attribute set, which restricts how many times the promotion can be used.
 


### PR DESCRIPTION
This seems like it should be displayed as code, like the other code keywords in the document.

The escape before the underscore (`_frontend`) is visible in GitHub's markdown renderer; I'm not sure if it is needed for the web.