### PR TITLE
Updating broken 4.2.0 releases link

### DIFF
--- a/upgrades/upgrades/four-dot-one-to-four-dot-two.md
+++ b/upgrades/upgrades/four-dot-one-to-four-dot-two.md
@@ -123,7 +123,7 @@ Or simply run `bundle exec rails g spree:frontend:copy_storefront`
 
 ## Read the release notes
 
-For information about changes contained within this release, please read the [4.2.0 Release Notes](https://guides.spreecommerce.org/release_notes/spree_4_2_0.html).
+For information about changes contained within this release, please read the [4.2.0 Release Notes](https://github.com/spree/spree/releases/tag/v4.2.0).
 
 ## More info
 


### PR DESCRIPTION
The previous link which is https://guides.spreecommerce.org/release_notes/4_2_0.html is not working anymore. So updated it with the https://github.com/spree/spree/releases/tag/v4.2.0 link.